### PR TITLE
Fixing intermittent text failures

### DIFF
--- a/modules/wss4j/test/wssec/TestWSSecurityWSS199.java
+++ b/modules/wss4j/test/wssec/TestWSSecurityWSS199.java
@@ -98,6 +98,9 @@ public class TestWSSecurityWSS199 extends TestCase implements CallbackHandler {
             LOG.debug(outputString);
         }
         try {
+            WSSConfig wssConfig = secEngine.getWssConfig();
+            wssConfig.setAllowNamespaceQualifiedPasswordTypes(false);
+            secEngine.setWssConfig(wssConfig);
             verify(doc);
             fail("Failure expected on a bad password type");
         } catch (WSSecurityException ex) {


### PR DESCRIPTION
Tests have assumed that tests run in predefined order, but here its not correct to assume like that since they are unit tests. They should be able to run in any order.