### PR TITLE
Fixing IDENTITY-4979

### DIFF
--- a/modules/wss4j/src/org/apache/ws/security/processor/UsernameTokenProcessor.java
+++ b/modules/wss4j/src/org/apache/ws/security/processor/UsernameTokenProcessor.java
@@ -166,6 +166,7 @@ public class UsernameTokenProcessor implements Processor {
             callbacks[0] = pwCb;
             try {
                 cb.handle(callbacks);
+                user = pwCb.getIdentifier();
             } catch (IOException e) {
                 if (log.isDebugEnabled()) {
                     log.debug(e);


### PR DESCRIPTION
Giving the ability to change the username from the CallbackHandler.handle() for WSPasswordCallback