### PR TITLE
Fix bug with getSecuredDocumentBuilder that resulted in a infinite lo…

### DIFF
--- a/modules/wss4j/src/org/apache/ws/security/util/XMLUtils.java
+++ b/modules/wss4j/src/org/apache/ws/security/util/XMLUtils.java
@@ -117,7 +117,7 @@ public class XMLUtils {
      */
     public static DocumentBuilderFactory getSecuredDocumentBuilder() {
 
-        DocumentBuilderFactory dbf = XMLUtils.getSecuredDocumentBuilder();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
         dbf.setXIncludeAware(false);
         dbf.setExpandEntityReferences(false);


### PR DESCRIPTION
…op causing a stack overflow message. Without this change, ESB 5.0.0 will return a stack overflow message when it processes a SOAP message with WS-Security tags.