### PR TITLE
Embed OpenSAML2 dependencies

### DIFF
--- a/modules/orbit/pom.xml
+++ b/modules/orbit/pom.xml
@@ -75,19 +75,8 @@
             <artifactId>opensaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>xmltooling</artifactId>
-            <version>${opensaml.xmltooling.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>openws</artifactId>
-            <version>${openws.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.owasp.esapi</groupId>
             <artifactId>esapi</artifactId>
-            <version>${esapi.version}</version>
         </dependency>
     </dependencies>
 
@@ -147,8 +136,8 @@
                             sun.security.util;resolution:=optional,
                         </Import-Package>
                         <Embed-Dependency>
-                            opensaml;inline=false, opensaml1;inline=false, xmltooling;inline=false,
-                            openws;inline=false, esapi;inline=false, bcprov-jdk15on;inline=false,
+                            opensaml;inline=false, opensaml1;inline=false,
+                            esapi;inline=false, bcprov-jdk15on;inline=false,
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <DynamicImport-Package>*</DynamicImport-Package>
@@ -165,11 +154,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <properties>
-        <opensaml.xmltooling.version>1.4.6</opensaml.xmltooling.version>
-        <openws.version>1.5.4</openws.version>
-        <esapi.version>2.1.0.1</esapi.version>
-    </properties>
 
 </project>

--- a/modules/orbit/pom.xml
+++ b/modules/orbit/pom.xml
@@ -77,17 +77,17 @@
         <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>xmltooling</artifactId>
-            <version>1.4.6</version>
+            <version>${opensaml.xmltooling.version}</version>
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>openws</artifactId>
-            <version>1.5.4</version>
+            <version>${openws.version}</version>
         </dependency>
         <dependency>
             <groupId>org.owasp.esapi</groupId>
             <artifactId>esapi</artifactId>
-            <version>2.1.0.1</version>
+            <version>${esapi.version}</version>
         </dependency>
     </dependencies>
 
@@ -165,5 +165,11 @@
             </plugin>
         </plugins>
     </build>
+
+    <properties>
+        <opensaml.xmltooling.version>1.4.6</opensaml.xmltooling.version>
+        <openws.version>1.5.4</openws.version>
+        <esapi.version>2.1.0.1</esapi.version>
+    </properties>
 
 </project>

--- a/modules/orbit/pom.xml
+++ b/modules/orbit/pom.xml
@@ -66,6 +66,29 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>xmltooling</artifactId>
+            <version>1.4.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>openws</artifactId>
+            <version>1.5.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.esapi</groupId>
+            <artifactId>esapi</artifactId>
+            <version>2.1.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -118,20 +141,15 @@
                             org.apache.xpath.objects;resolution:=optional,
                             org.ietf.jgss,
                             org.joda.time,
-                            org.opensaml,
-                            org.opensaml.saml2.core,
-                            org.opensaml.xml,
-                            org.opensaml.xml.io,
-                            org.opensaml.xml.security.credential,
-                            org.opensaml.xml.security.x509,
-                            org.opensaml.xml.signature,
-                            org.opensaml.xml.util,
-                            org.opensaml.xml.validation,
                             org.w3c.dom,
                             org.xml.sax,
                             sun.security.krb5.*;resolution:=optional,
                             sun.security.util;resolution:=optional,
                         </Import-Package>
+                        <Embed-Dependency>
+                            opensaml;inline=false, opensaml1;inline=false, xmltooling;inline=false,
+                            openws;inline=false, esapi;inline=false, bcprov-jdk15on;inline=false,
+                        </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bcprov.jdk15on.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.owasp.esapi</groupId>
+                <artifactId>esapi</artifactId>
+                <version>${esapi.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -173,6 +178,7 @@
         <jacoco.maven.plugin.version>0.8.4</jacoco.maven.plugin.version>
         <opensaml.version>2.6.1</opensaml.version>
         <opensaml1.version>1.1</opensaml1.version>
+        <esapi.version>2.1.0.1</esapi.version>
         <slf4j.jdk14.version>1.7.26</slf4j.jdk14.version>
         <wss4j.version>1.5.11-wso2v18-SNAPSHOT</wss4j.version>
         <exp.pkg.version.wss4j>${wss4j.version}</exp.pkg.version.wss4j>


### PR DESCRIPTION
## Purpose
- To remove exposure of OpenSAML2 dependencies to product-is

## Goals
- Embed the required OpenSAML2 dependencies.