### PR TITLE
Avoid exporting org.apache.xml.security package

### DIFF
--- a/modules/orbit/pom.xml
+++ b/modules/orbit/pom.xml
@@ -81,16 +81,13 @@
                         <Export-Package>
                             org.apache.ws.security.*; version=${exp.pkg.version.wss4j},
                             org.apache.ws.axis.security.*; version=${exp.pkg.version.wss4j},
-                            javax.xml.crypto.*; version=${exp.pkg.version.xmlsec},
-                            org.apache.xml.security.*; version=${exp.pkg.version.xmlsec},
-                            org.jcp.xml.dsig.internal.*; version=${exp.pkg.version.xmlsec}
                         </Export-Package>
                         <Import-Package>
                             !org.apache.ws.security.*; version="${imp.pkg.version.wss4j}",
                             !org.apache.ws.axis.security.*; version="${imp.pkg.version.wss4j}",
-                            !javax.xml.crypto.*; version="${imp.pkg.version.xmlsec}",
-                            !org.apache.xml.security.*; version="${imp.pkg.version.xmlsec}",
-                            !org.jcp.xml.dsig.internal.*; version="${imp.pkg.version.xmlsec}",
+                            javax.xml.crypto.*; version="${imp.pkg.version.xmlsec}",
+                            org.apache.xml.security.*; version="${imp.pkg.version.xmlsec}",
+                            org.jcp.xml.dsig.internal.*; version="${imp.pkg.version.xmlsec}",
                             org.bouncycastle.*; version="${imp.pkg.version.bcp}",
                             org.apache.axis.*;version="${imp.pkg.version.axis2}";resolution:=optional,
                             javax.xml.soap; version="${imp.pkg.version.xmlsoap}";resolution:=optional,


### PR DESCRIPTION
- Avoid exporting org.apache.xml.security package cause this will be exported by the xmlsec jar introduced in https://github.com/wso2/carbon-identity-framework/pull/2921.

Resolves: https://github.com/wso2/product-is/issues/8350