### PR TITLE
Introduce system property to change crypto provider

### DIFF
--- a/modules/wss4j/src/org/apache/ws/security/WSSConfig.java
+++ b/modules/wss4j/src/org/apache/ws/security/WSSConfig.java
@@ -49,6 +49,9 @@ public class WSSConfig {
     
     private static final Log log = LogFactory.getLog(WSSConfig.class.getName());
 
+    public static final String BOUNCY_CASTLE_PROVIDER = "BC";
+    public static final String BOUNCY_CASTLE_FIPS_PROVIDER = "BCFIPS";
+
     /**
      * The default collection of actions supported by the toolkit.
      */
@@ -305,7 +308,12 @@ public class WSSConfig {
                  * The last provider added has precedence, that is if JuiCE can be added
                  * then WSS4J uses this provider.
                  */
-                addJceProvider("BC", "org.bouncycastle.jce.provider.BouncyCastleProvider");
+                String jceProvider = getPreferredJceProvider();
+                if (BOUNCY_CASTLE_FIPS_PROVIDER.equals(jceProvider)) {
+                    addJceProvider(BOUNCY_CASTLE_FIPS_PROVIDER, "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider");
+                } else {
+                    addJceProvider(BOUNCY_CASTLE_PROVIDER, "org.bouncycastle.jce.provider.BouncyCastleProvider");
+                }
                 addJceProvider("JuiCE", "org.apache.security.juice.provider.JuiCEProviderOpenSSL");
             }
             //Transform.init();
@@ -667,5 +675,18 @@ public class WSSConfig {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Get the preferred JCE provider.
+     *
+     * @return the preferred JCE provider.
+     */
+    private static String getPreferredJceProvider() {
+        String provider = System.getProperty("security.jce.provider");
+        if (BOUNCY_CASTLE_FIPS_PROVIDER.equalsIgnoreCase(provider)) {
+            return BOUNCY_CASTLE_FIPS_PROVIDER;
+        }
+        return BOUNCY_CASTLE_PROVIDER;
     }
 }


### PR DESCRIPTION
## Purpose
This PR introduces a new System property `security.jce.provider` which can be used to change the Crypto Provider from its default `BouncyCastleProvider` for  `BouncyCastleFipsProvider`.

Related to https://github.com/wso2/api-manager/issues/1219

## Approach
To toggle the Crypto Provider to the `BouncyCastleFipsProvider` provider, provide the following system provider while starting up the server.

```sh
... -Dsecurity.jce.provider=BCFIPS ...
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes