### PR TITLE
Bump xmlsec versions and implement new abstract methods in EnvelopeIdResolver class

### DIFF
--- a/modules/wss4j/src/org/apache/ws/security/message/EnvelopeIdResolver.java
+++ b/modules/wss4j/src/org/apache/ws/security/message/EnvelopeIdResolver.java
@@ -27,6 +27,7 @@ import org.apache.ws.security.WSDocInfo;
 import org.apache.ws.security.util.URI;
 import org.apache.ws.security.util.WSSecurityUtil;
 import org.apache.xml.security.signature.XMLSignatureInput;
+import org.apache.xml.security.utils.resolver.ResourceResolverContext;
 import org.apache.xml.security.utils.resolver.ResourceResolverException;
 import org.apache.xml.security.utils.resolver.ResourceResolverSpi;
 import org.w3c.dom.Attr;
@@ -65,7 +66,34 @@ public class EnvelopeIdResolver extends ResourceResolverSpi {
 
     private EnvelopeIdResolver() {
     }
-    
+
+    /**
+     * This is the workhorse method used to resolve resources.
+     *
+     * @param resourceResolverContext
+     * @return
+     * @throws ResourceResolverException
+     */
+    @Override
+    public XMLSignatureInput engineResolveURI(ResourceResolverContext resourceResolverContext)
+            throws ResourceResolverException {
+
+        return this.engineResolve(resourceResolverContext.attr, resourceResolverContext.baseUri);
+    }
+
+    /**
+     * This method helps the ResourceResolver to decide whether a
+     * ResourceResolverSpi is able to perform the requested action.
+     *
+     * @param resourceResolverContext
+     * @return
+     */
+    @Override
+    public boolean engineCanResolveURI(ResourceResolverContext resourceResolverContext) {
+
+        return this.engineCanResolve(resourceResolverContext.attr, resourceResolverContext.baseUri);
+    }
+
     /**
      * @param docInfo The WSDocInfo object to be used for resolving elements
      */
@@ -124,7 +152,7 @@ public class EnvelopeIdResolver extends ResourceResolverSpi {
             if (selectedElem == null) {
                 throw new ResourceResolverException("generic.EmptyMessage",
                         new Object[]{"Body element not found"},
-                        uri,
+                        String.valueOf(uri),
                         BaseURI);
             }
             String cId = selectedElem.getAttributeNS(WSConstants.WSU_NS, "Id");
@@ -145,7 +173,7 @@ public class EnvelopeIdResolver extends ResourceResolverSpi {
                 if (cId == null) {
                     throw new ResourceResolverException("generic.EmptyMessage",
                             new Object[]{"Id not found"},
-                            uri,
+                            String.valueOf(uri),
                             BaseURI);
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 
     <properties>
         <wss4j.wso2.version>${wss4j.version}</wss4j.wso2.version>
-        <xmlsec.version>1.5.2</xmlsec.version>
+        <xmlsec.version>2.1.7</xmlsec.version>
         <xml.apis.version>2.0.2</xml.apis.version>
         <bcprov.jdk14.version>1.49</bcprov.jdk14.version>
         <bcprov.jdk15.version>1.49</bcprov.jdk15.version>


### PR DESCRIPTION
## Purpose
This PR contains implementation behind the version migration happened for xmlsec dependency. Currently, the all the packs uses 2.1.7 xmlsec version and this component need to implement the newly introduced abstract methods, otherwise the runtime env will throw an error.

### When this PR should be merged
- With all the relevant PR

### Relavant PRs
- https://github.com/wso2-support/wso2-axiom/pull/64

### Related Issues
- https://github.com/wso2/product-is/issues/15697
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/429
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/189