### PR TITLE
Bump xmlsec versions and implement new abstract methods in TransformSpi class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 
     <properties>
         <wss4j.wso2.version>${wss4j.version}</wss4j.wso2.version>
-        <xmlsec.version>2.1.7</xmlsec.version>
+        <xmlsec.version>2.3.4</xmlsec.version>
         <xml.apis.version>2.0.2</xml.apis.version>
         <bcprov.jdk14.version>1.49</bcprov.jdk14.version>
         <bcprov.jdk15.version>1.49</bcprov.jdk15.version>


### PR DESCRIPTION
## Purpose
- Need to Update xmlsec version to 2.3.4
- This PR contains implementation behind the version migration happened for xmlsec dependency. Components that uses the xmlsec dependecy needs to be implemented and compiled using the newly introduced abstract methods of the xml dependency, otherwise the build will failed.

## Related Issue
- https://github.com/wso2/product-is/issues/17989

## References
- https://github.com/apache/santuario-xml-security-java/commit/b32e6317e7d8c1519093e01a1f8326489b040195
- https://github.com/apache/santuario-xml-security-java/commit/0302cd2b2f0785b37dc8ea3ec976aed3955e97ec
- https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311231&version=12344983
